### PR TITLE
Fix dependency and cipher32 rounds

### DIFF
--- a/cipher32.go
+++ b/cipher32.go
@@ -9,40 +9,40 @@ import (
 )
 
 const (
-	W32 		= 32		// word size in bits
-	WW32		= W32 / 8 	// word size in bytes
-	B32 		= 64 		// block size in bits
-	BB32 		= B32 / 8 	// block size in bytes
-	P32			= 0xb7e15163
-  	Q32 		= 0x9e3779b9
+	W32  = 32      // word size in bits
+	WW32 = W32 / 8 // word size in bytes
+	B32  = 64      // block size in bits
+	BB32 = B32 / 8 // block size in bytes
+	P32  = 0xb7e15163
+	Q32  = 0x9e3779b9
 )
 
 type cipher32 struct {
-	K 				[]byte 			// secret key
-	b 				uint 			// byte length of secret key
-	R 				uint 			// number of rounds
-	S 				[]uint32 		// expanded key table
-	T 				uint 			// number of words in expanded key table
+	K []byte   // secret key
+	b uint     // byte length of secret key
+	R uint     // number of rounds
+	S []uint32 // expanded key table
+	T uint     // number of words in expanded key table
 }
 
 func getUint32(b []byte) uint32 {
-	return uint32(b[0]) 	   |
-		   uint32(b[1]) <<   8 |
-		   uint32(b[2]) <<  16 |
-		   uint32(b[3]) <<  24
+	return uint32(b[0]) |
+		uint32(b[1])<<8 |
+		uint32(b[2])<<16 |
+		uint32(b[3])<<24
 }
 
 func get32(b []byte) (uint32, uint32) {
 	return getUint32(b[:4]), getUint32(b[4:])
 }
 
-func put32(dst[] byte, a uint32, b uint32) {
+func put32(dst []byte, a uint32, b uint32) {
 	dst[0] = byte(a)
-	dst[1] = byte(a >>  8)
+	dst[1] = byte(a >> 8)
 	dst[2] = byte(a >> 16)
 	dst[3] = byte(a >> 24)
 	dst[4] = byte(b)
-	dst[5] = byte(b >>  8)
+	dst[5] = byte(b >> 8)
 	dst[6] = byte(b >> 16)
 	dst[7] = byte(b >> 24)
 }
@@ -50,7 +50,7 @@ func put32(dst[] byte, a uint32, b uint32) {
 func putUint32(k uint32) []byte {
 	b := make([]byte, 4)
 	b[0] = byte(k)
-	b[1] = byte(k >>  8)
+	b[1] = byte(k >> 8)
 	b[2] = byte(k >> 16)
 	b[3] = byte(k >> 24)
 	return b
@@ -69,7 +69,7 @@ func NewCipher32(key []byte, rounds uint) (cipher.Block, error) {
 	if n := len(key); n > 255 {
 		return nil, KeySizeError(n)
 	}
-	return newCipher32(key, 12)
+	return newCipher32(key, rounds)
 }
 
 func newCipher32(key []byte, rounds uint) (*cipher32, error) {
@@ -77,25 +77,25 @@ func newCipher32(key []byte, rounds uint) (*cipher32, error) {
 	L, LL := bytesToWords32(key, rounds)
 	S, T = expandKeyTable32(S, T, L, LL)
 
-    c := cipher32{
-    	key,
-    	uint(len(key) / 8),
-    	rounds,
-    	S,
-    	T,
-    }
-    return &c, nil
+	c := cipher32{
+		key,
+		uint(len(key) / 8),
+		rounds,
+		S,
+		T,
+	}
+	return &c, nil
 }
 
 func (c *cipher32) BlockSize() int { return B32 }
 
 func (c *cipher32) Encrypt(dst, src []byte) {
 	A, B := get32(src)
-	A, B = A + c.S[0], B + c.S[1]
+	A, B = A+c.S[0], B+c.S[1]
 
 	for i := uint(1); i <= c.R; i++ {
-		A = rotl32(A^B, B&31) + c.S[2 * i]
-		B = rotl32(B^A, A&31) + c.S[2 * i + 1]
+		A = rotl32(A^B, B&31) + c.S[2*i]
+		B = rotl32(B^A, A&31) + c.S[2*i+1]
 	}
 
 	put32(dst, A, B)
@@ -105,8 +105,8 @@ func (c *cipher32) Decrypt(dst, src []byte) {
 	A, B := get32(src)
 
 	for i := int(c.R); i >= 1; i-- {
-		B = rotr32(B - c.S[2 *i + 1], A&31) ^ A
-		A = rotr32(A - c.S[2 * i], B&31) ^ B
+		B = rotr32(B-c.S[2*i+1], A&31) ^ A
+		A = rotr32(A-c.S[2*i], B&31) ^ B
 	}
 
 	B = B - c.S[1]
@@ -119,12 +119,12 @@ func newKeyTable32(R uint) ([]uint32, uint) {
 	T := 2 * (R + 1)
 	S := make([]uint32, T)
 
-    S[0] = P32
-    for i := uint(1); i < T; i++  {
-    	S[i] = S[i-1] + Q32
-    }
+	S[0] = P32
+	for i := uint(1); i < T; i++ {
+		S[i] = S[i-1] + Q32
+	}
 
-    return S, T
+	return S, T
 }
 
 func bytesToWords32(key []byte, blockSize uint) ([]uint32, uint) {
@@ -141,7 +141,7 @@ func bytesToWords32(key []byte, blockSize uint) ([]uint32, uint) {
 
 func expandKeyTable32(S []uint32, T uint, L []uint32, LL uint) ([]uint32, uint) {
 	k := 3 * T
-	if (LL > T) {
+	if LL > T {
 		k = 3 * LL
 	}
 
@@ -149,13 +149,13 @@ func expandKeyTable32(S []uint32, T uint, L []uint32, LL uint) ([]uint32, uint) 
 	i, j := uint(0), uint(0)
 
 	for ; k > 0; k-- {
-        A = rotl32(S[i] + A + B, 3)
-        S[i] = A
-        B = rotl32(L[j] + A + B, (A + B)&31)
-        L[j] = B
-        i = (i + 1) % T
-        j = (j + 1) % LL
-    }
+		A = rotl32(S[i]+A+B, 3)
+		S[i] = A
+		B = rotl32(L[j]+A+B, (A+B)&31)
+		L[j] = B
+		i = (i + 1) % T
+		j = (j + 1) % LL
+	}
 
-    return S, T
+	return S, T
 }

--- a/cipher32_test.go
+++ b/cipher32_test.go
@@ -6,8 +6,15 @@ package rc5
 
 import (
 	"bytes"
-	"testing"
+	"encoding/hex"
 	"math/rand"
+	"testing"
+)
+
+const (
+	encKey        = "30D5DDB906436F6D3C5B21FCCC2B6A3B30D5DDB9"
+	plainData     = "010000000000000000804200626F743083626F7400000000CB5257151757F728FD704666598D4A730000000000000007"
+	encryptedData = "4D840AB1DD57828AD4DD25DF8EE253009622FC479AE35A2A085181144C4E32B6EED1CE0666A649B50473E6D49DECEE94"
 )
 
 func TestCipher32(t *testing.T) {
@@ -19,17 +26,48 @@ func TestCipher32(t *testing.T) {
 
 	for i := 0; i < max; i++ {
 		key := make([]byte, 16)
-    	random.Read(key)
-    	value := make([]byte, 8)
-    	random.Read(value)
+		random.Read(key)
+		value := make([]byte, 8)
+		random.Read(value)
 
-    	cipher, _ := NewCipher32(key, 12)
+		cipher, _ := NewCipher32(key, 12)
 
 		cipher.Encrypt(encrypted[:], value)
 		cipher.Decrypt(decrypted[:], encrypted[:])
 
 		if !bytes.Equal(decrypted[:], value[:]) {
-			t.Errorf("encryption/decryption failed: % 02x != % 02x\n", decrypted, value)	
+			t.Errorf("encryption/decryption failed: % 02x != % 02x\n", decrypted, value)
 		}
 	}
+}
+
+func TestCipher32Known(t *testing.T) {
+
+	var (
+		key, _       = hex.DecodeString(encKey)
+		plain, _     = hex.DecodeString(plainData)
+		encrypted, _ = hex.DecodeString(encryptedData)
+
+		cipher, _ = NewCipher32(key, 16)
+
+		cipherText = make([]uint8, len(plain))
+		plainText  = make([]uint8, len(plain))
+	)
+
+	for i := 0; i < len(plain); i += 8 {
+		cipher.Encrypt(cipherText[i:i+8], plain[i:i+8])
+	}
+
+	for i := 0; i < len(encrypted); i += 8 {
+		cipher.Decrypt(plainText[i:i+8], encrypted[i:i+8])
+	}
+
+	if !bytes.Equal(encrypted, cipherText) {
+		t.Errorf("encryption failed: %X != %s\n", cipherText, encryptedData)
+	}
+
+	if !bytes.Equal(plain, plainText) {
+		t.Errorf("decryption failed: %X != %s\n", plainText, plainData)
+	}
+
 }

--- a/cipherBig.go
+++ b/cipherBig.go
@@ -7,7 +7,8 @@ package rc5
 import (
 	"crypto/cipher"
 	"math/big"
-	"scorpioncompute.com/bigmath"
+
+	"github.com/euphratesdata/go-bigmath"
 )
 
 var one = big.NewInt(1)


### PR DESCRIPTION
In this PR I fixed the following problems

- an unavailable testing dependency for cipherBig (bigmath)
- a hardcoded value of 12 for the rounds used in NewCipher32